### PR TITLE
Fixed bug where hex characters were being saved to char arrayinstead …

### DIFF
--- a/P1/src/Utilizacion_API/os_API.c
+++ b/P1/src/Utilizacion_API/os_API.c
@@ -389,21 +389,22 @@ int os_read(osFILE* file_desc, void* buffer, int nbytes){
    // obtener puntero absoulto de comienzo de la particion
    int puntero_abs_particion = disk->directory.directory_byte_pos;
    // indice del bloque de incio de la lectura 
-   int bloque_inicio_lectura = floor(file_desc->bytes_read/2048);
-   int offset_bloque =  file_desc->bytes_read - bloque_inicio_lectura*2048 ;
+   unsigned long int bloque_inicio_lectura = floor(file_desc->bytes_read/2048);
+   unsigned long int offset_bloque =  file_desc->bytes_read - bloque_inicio_lectura*2048 ;
    int i=0; 
    int primer_bloque = 1;
    //nos posicionamos en el bloque indice donde debemos empezar a leer
    
    while(i < n_bytes_a_leer){
      fseek(disk ->file_pointer, file_desc->index_ptr + 5 + bloque_inicio_lectura * 3, SEEK_SET);
-     char posicion_relativa[3];
+     unsigned char posicion_relativa[3] = "";
      fread(posicion_relativa, sizeof(unsigned char), 3, disk -> file_pointer);
      unsigned long int pos_relativa_bloque_datos = (posicion_relativa[0]<<16)|(posicion_relativa[1]<<8)|posicion_relativa[2];
+     //printf("pos relativa bloque de datos: %lu\n", pos_relativa_bloque_datos);
      //llegamos al puntero de bloque de datos
      if(primer_bloque){
       fseek(disk -> file_pointer, puntero_abs_particion + pos_relativa_bloque_datos*2048 + offset_bloque, SEEK_SET);
-      printf("ubicacion bloque datos: %i %lu\n",bloque_inicio_lectura ,puntero_abs_particion + pos_relativa_bloque_datos*2048 + offset_bloque);
+      printf("ubicacion bloque datos: %lu %lu\n",bloque_inicio_lectura ,puntero_abs_particion + pos_relativa_bloque_datos*2048 + offset_bloque);
       fread(buffer + i, sizeof(unsigned char), 2048-offset_bloque , disk ->file_pointer);
       primer_bloque = 0;
       i+=(2048-offset_bloque);
@@ -412,14 +413,14 @@ int os_read(osFILE* file_desc, void* buffer, int nbytes){
      }
      else if(n_bytes_a_leer - i <= 2048){
        fseek(disk ->file_pointer, puntero_abs_particion + pos_relativa_bloque_datos*2048, SEEK_SET);
-       printf("ubicacion bloque datos: %i %lu\n",bloque_inicio_lectura , puntero_abs_particion + pos_relativa_bloque_datos*2048);
+       printf("ubicacion bloque datos: %lu %lu\n",bloque_inicio_lectura , puntero_abs_particion + pos_relativa_bloque_datos*2048);
        fread(buffer + i, sizeof(unsigned char), n_bytes_a_leer - i  , disk -> file_pointer);
        i+= n_bytes_a_leer - i ;
       }
        
      else{
         fseek(disk -> file_pointer, puntero_abs_particion + pos_relativa_bloque_datos*2048, SEEK_SET);
-        printf("ubicacion bloque datos: %i %lu\n",bloque_inicio_lectura , puntero_abs_particion + pos_relativa_bloque_datos*2048);
+        printf("ubicacion bloque datos: %lu %lu\n",bloque_inicio_lectura , puntero_abs_particion + pos_relativa_bloque_datos*2048);
         fread(buffer + i, sizeof(unsigned char), 2048 , disk -> file_pointer);
         i+= 2048;
 

--- a/P1/src/Utilizacion_API/os_API.h
+++ b/P1/src/Utilizacion_API/os_API.h
@@ -23,10 +23,10 @@ typedef struct disk
 
 typedef struct osFILE {
     char name[28];
-    unsigned int index_ptr;
-    unsigned int directory_ptr;
-    unsigned int size;
-    unsigned int bytes_read;
+    unsigned long int index_ptr;
+    unsigned long int directory_ptr;
+    unsigned long int size;
+    unsigned long int bytes_read;
 }osFILE;
 
 

--- a/P1/src/osfs/main.c
+++ b/P1/src/osfs/main.c
@@ -45,9 +45,9 @@ int main(int argc, char **argv)
     char* name = "dog.mp3";
     osFILE* os_file=os_open(name,'r');  //osFILE* os_file= 
     printf("printando\n");
-    //printf("Nombre  %s",os_file->name);
-    //printf("Directory ptr: %d", os_file->directory_ptr);
-    //printf("index ptr: %d", os_file->index_ptr);
+    // printf("Nombre  %s",os_file->name);
+    // printf("Directory ptr: %d", os_file->directory_ptr);
+    // printf("index ptr: %d", os_file->index_ptr);
     // printf('Size: %d', os_file->size);
     /* Forma para hacer con array*/
     //Ponemos el puntero al inicio del archivo


### PR DESCRIPTION
Fixed bug where hex characters were being saved to char array instead of unsigned char array. 
Changed ints for unsigned long ints, because bytes can go to 4 billion and max int size is 2 billion.

Unsigned long int max size is 4294967295  so it works better